### PR TITLE
メニュー機能を bottom sheet に寄せて、スマホで使いやすいようにする

### DIFF
--- a/components/Menu.vue
+++ b/components/Menu.vue
@@ -1,0 +1,44 @@
+<template lang="pug">
+  v-bottom-sheet(v-model="isShow" lazy)
+    v-btn(slot="activator" fab fixed bottom left color="secondary")
+      v-icon menu
+    v-list
+      v-list-tile(@click="isShow = false" to="/")
+        v-list-tile-action
+          v-icon home
+        v-list-tile-content
+          v-list-tile-title Home
+      v-list-tile(disabled)
+        v-list-tile-action
+          v-icon settings
+        v-list-tile-content
+          v-list-tile-title Settings
+      v-list-tile(@click="signOut" v-if="isAuthenticated")
+        v-list-tile-action
+          v-icon flight_takeoff
+        v-list-tile-content
+          v-list-tile-title Sign Out
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+
+export default {
+  data() {
+    return {
+      isShow: false
+    }
+  },
+  computed: {
+    ...mapGetters('auth', ['isAuthenticated'])
+  },
+  methods: {
+    ...mapActions('auth', { authSignOut: 'signOut' }),
+    signOut: async function() {
+      await this.authSignOut()
+      await this.$router.push('/sign-in')
+      this.isShow = false
+    }
+  }
+}
+</script>

--- a/components/ScrollToTop.vue
+++ b/components/ScrollToTop.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   div(v-scroll="onScroll")
     v-fab-transition
-      v-btn(app fab fixed bottom right color="primary" v-if="offsetTop > boundary" @click="$vuetify.goTo(0)")
+      v-btn(fab fixed bottom right color="primary" v-if="offsetTop > boundary" @click="$vuetify.goTo(0)")
         v-icon keyboard_arrow_up
 </template>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,13 +1,8 @@
 <template lang="pug">
   v-app
-    v-toolbar(app)
-      v-toolbar-items
-        v-btn(flat large @click="$router.push('/')") FYI Stocker
-      v-spacer
-      v-toolbar-items
-        v-btn(flat v-if="isAuthenticated" @click="signOut")
-          .mr-2 Sign Out
-          v-icon flight_takeoff
+    v-menu
+    v-toolbar(app dark color="primary")
+      v-toolbar-title FYI Stocker
     v-content
       v-container
         nuxt
@@ -19,22 +14,13 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import Menu from '~/components/Menu'
 import ScrollToTop from '~/components/ScrollToTop'
 
 export default {
   components: {
-    'v-scroll-to-top': ScrollToTop
-  },
-  computed: {
-    ...mapGetters('auth', ['isAuthenticated'])
-  },
-  methods: {
-    ...mapActions('auth', { authSignOut: 'signOut' }),
-    signOut: async function() {
-      await this.authSignOut()
-      await this.$router.push('/sign-in')
-    }
+    'v-scroll-to-top': ScrollToTop,
+    'v-menu': Menu
   }
 }
 </script>


### PR DESCRIPTION
これによって、レイアウトからロジックを別離することができる。
Settings は TODO だけど、見栄え的に先に置いておく。
