### PR TITLE
モバイルで見やすいように、アクションはモーダルに押し込める

### DIFF
--- a/components/ContributeForm.vue
+++ b/components/ContributeForm.vue
@@ -12,6 +12,10 @@
         template(v-else)
           v-btn(type="submit" large color="primary" @click="update" :disabled="!valid || loading" :loading="loading") Update
           v-btn(type="button" large color="accent" @click="$emit('close')" :disabled="loading" :loading="loading") Cancel
+      template(v-if="mode === 'edit'")
+        v-divider.my-2
+        v-card-actions
+          v-btn(type="button" large color="error" @click="remove" :disabled="loading" :loading="loading") Remove
 </template>
 
 <script>
@@ -52,7 +56,8 @@ export default {
   methods: {
     ...mapActions('contributes', {
       addContribute: 'add',
-      updateContribute: 'update'
+      updateContribute: 'update',
+      deleteContribute: 'delete'
     }),
     add() {
       if (!this.$refs.form.validate()) {
@@ -71,6 +76,14 @@ export default {
       }
 
       this.updateContribute(this.convertContribute())
+      this.$emit('close')
+    },
+    async remove() {
+      if (!confirm('Are you sure you want to delete this contribute?')) {
+        return false
+      }
+
+      await this.deleteContribute(this.contribute)
       this.$emit('close')
     },
     clear() {

--- a/components/ContributeTable.vue
+++ b/components/ContributeTable.vue
@@ -8,14 +8,10 @@
         v-text-field(v-model="search" append-icon="search" label="Search" single-line hide-details)
       v-data-table(:headers="headers" :items="contributes" :search="search" :loading="loading" :rows-per-page-items="rowsPerPageItems" disable-initial-sort)
         template(slot="items" slot-scope="props")
-          td.text-no-wrap {{ props.item.at }}
-          td.px-0.py-2
-            a(:href="props.item.url" target="_blank") {{ props.item.title }}
-          td.layout.justify-center.align-center
-            v-btn.mx-1(flat icon small @click="edit(props.item)")
-              v-icon edit
-            v-btn.mx-1(flat icon small color="error" @click="remove(props.item)")
-              v-icon delete
+          tr(@click="edit(props.item)")
+            td.text-no-wrap {{ props.item.at }}
+            td.pl-0.py-2
+              a(:href="props.item.url" target="_blank") {{ props.item.title }}
 </template>
 
 <script>
@@ -30,8 +26,7 @@ export default {
     return {
       headers: [
         { text: 'at', value: 'at' },
-        { text: 'link', value: 'title', class: 'px-0' },
-        { text: 'actions', value: 'name', sortable: false, align: 'center' }
+        { text: 'link', value: 'title', class: 'pl-0' }
       ],
       dialog: false,
       editedContribute: null,


### PR DESCRIPTION
テーブル内に actions を置くのをやめる。
編集モーダルを開いたとき、その中から削除できるようにする。

これで、モバイルでも少し見やすくなるはず。
